### PR TITLE
fix: update moonPlatform to use moon-patched

### DIFF
--- a/lib/moonPlatform/default.nix
+++ b/lib/moonPlatform/default.nix
@@ -24,8 +24,14 @@
 let
   inherit (import ../utils.nix { inherit stdenv lib; }) mkCliUri mkCoreUri target;
 
+  moon-patched = callPackage ./moon-patched {
+    rev = versions.${version}.moonRev;
+    hash = versions.${version}.moonHash;
+  };
+
   cli = callPackage ../cli.nix {
     inherit version;
+    moon-patched = moon-patched;
     url = mkCliUri version;
     hash = versions."${version}"."${target}-cliHash";
   };


### PR DESCRIPTION
```nix
nix build .#checks.x86_64-linux.testBuildMoonPackage
```
should built successfully.