### PR TITLE
fix(moonPlatform): fix buildMoonPackage for recent moon versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ directory — minimal configuration is needed:
         };
 
         packages.default = pkgs.moonPlatform.buildMoonPackage {
-          name = "my-brilliant-moonbit-project";
           src = ./.;
           moonModJson = ./moon.mod.json;
           moonRegistryIndex = inputs.moon-registry;
@@ -132,6 +131,7 @@ directory — minimal configuration is needed:
 
 | Parameter            | Default                             | Description                                    |
 | -------------------- | ----------------------------------- | ---------------------------------------------- |
+| `name`               | from `moon.mod.json`                | Derivation name (last component of mod name)   |
 | `version`            | from `moon.mod.json`                | Package version                                |
 | `moonTarget`         | `preferred-target` in moon.mod.json | Build target (`native`, `js`, `wasm`, etc.)    |
 | `moonFlags`          | `[]`                                | Extra flags passed to `moon build`             |

--- a/README.md
+++ b/README.md
@@ -76,49 +76,64 @@ nix flake init -t github:moonbit-community/moonbit-overlay
 
 ## Moonbit Package Builder
 
+`buildMoonPackage` builds a MoonBit project from source inside the Nix sandbox.
+It reads `moon.mod.json` to auto-detect version, preferred target, and source
+directory — minimal configuration is needed:
+
 ```nix
-
 {
-  description = "A startup basic MoonBit project";
-
   inputs = {
-    flake-parts.url = "github:hercules-ci/flake-parts";
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     moonbit-overlay.url = "github:moonbit-community/moonbit-overlay";
     moon-registry = {
-      url = "mooncakes.io/git/index";
+      url = "git+https://mooncakes.io/git/index";
       flake = false;
     };
   };
 
-  outputs = inputs@{ flake-parts, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } {
-
-      perSystem = { inputs', system, pkgs, ... }: {
-        _module.args.pkgs = import inputs.nixpkgs {
-          inherit system;
-          overlays = [ inputs.moonbit-overlay.overlays.default ];
-        };
-
-        packages.default = pkgs.moonPlatform.buildMoonPackage {
-          name = "my-brilliant-moonbit-project";
-          src = ./.;
-          version = "0.1.0";
-          moonModJson = ./moon.mod.json;
-          moonRegistryIndex = inputs.moon-registry;
-          moonFlags = [ "--release" ];
-        }
+  outputs = { nixpkgs, moonbit-overlay, moon-registry, ... }:
+    let
+      system = "aarch64-darwin"; # or x86_64-linux, x86_64-darwin
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [ moonbit-overlay.overlays.default ];
       };
-
-      systems = [
-        "x86_64-linux"
-        "aarch64-darwin"
-        "x86_64-darwin"
-      ];
+    in {
+      packages.${system}.default = pkgs.moonPlatform.buildMoonPackage {
+        name = "my-app";
+        src = ./.;
+        moonModJson = ./moon.mod.json;
+        moonRegistryIndex = moon-registry;
+      };
     };
 }
 ```
+
+### What it does automatically
+
+- Resolves and caches all transitive dependencies from `mooncakes.io` registry
+- Reads `version`, `preferred-target`, and `source` from `moon.mod.json`
+- Builds with `moon build --target <preferred-target> --release`
+- Installs all produced binaries to `$out/bin/`
+
+### Optional parameters
+
+| Parameter            | Default                             | Description                                    |
+| -------------------- | ----------------------------------- | ---------------------------------------------- |
+| `version`            | from `moon.mod.json`                | Package version                                |
+| `moonTarget`         | `preferred-target` in moon.mod.json | Build target (`native`, `js`, `wasm`, etc.)    |
+| `moonFlags`          | `[]`                                | Extra flags passed to `moon build`             |
+| `buildPhase`         | auto-generated                      | Override the build phase                       |
+| `installPhase`       | auto-generated                      | Override the install phase                     |
+| `nativeBuildInputs`  | `[]`                                | Merged with moonbit toolchain                  |
+
+### Public API
+
+`moonPlatform` exposes three functions:
+
+- `buildMoonPackage` — high-level builder (shown above)
+- `buildCachedRegistry` — fetch and cache mooncakes.io dependencies
+- `bundleWithRegistry` — create a complete `MOON_HOME` with toolchain + core + registry
 
 ## Bundled MoonBit Toolchains
 

--- a/README.md
+++ b/README.md
@@ -82,8 +82,12 @@ directory — minimal configuration is needed:
 
 ```nix
 {
+  description = "A startup basic MoonBit project";
+
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
     moonbit-overlay.url = "github:moonbit-community/moonbit-overlay";
     moon-registry = {
       url = "git+https://mooncakes.io/git/index";
@@ -91,20 +95,28 @@ directory — minimal configuration is needed:
     };
   };
 
-  outputs = { nixpkgs, moonbit-overlay, moon-registry, ... }:
-    let
-      system = "aarch64-darwin"; # or x86_64-linux, x86_64-darwin
-      pkgs = import nixpkgs {
-        inherit system;
-        overlays = [ moonbit-overlay.overlays.default ];
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+
+      perSystem = { inputs', system, pkgs, ... }: {
+        _module.args.pkgs = import inputs.nixpkgs {
+          inherit system;
+          overlays = [ inputs.moonbit-overlay.overlays.default ];
+        };
+
+        packages.default = pkgs.moonPlatform.buildMoonPackage {
+          name = "my-brilliant-moonbit-project";
+          src = ./.;
+          moonModJson = ./moon.mod.json;
+          moonRegistryIndex = inputs.moon-registry;
+        };
       };
-    in {
-      packages.${system}.default = pkgs.moonPlatform.buildMoonPackage {
-        name = "my-app";
-        src = ./.;
-        moonModJson = ./moon.mod.json;
-        moonRegistryIndex = moon-registry;
-      };
+
+      systems = [
+        "x86_64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
     };
 }
 ```

--- a/lib/moonPlatform/buildCachedRegistry.nix
+++ b/lib/moonPlatform/buildCachedRegistry.nix
@@ -38,8 +38,7 @@ let
           };
         in
         ''
-          mkdir -p $out/registry/cache/${dep.name}
-          cp ${cache} $out/registry/cache/${dep.name}/${dep.version}.zip
+          install -Dm644 ${cache} $out/registry/cache/${dep.name}/${dep.version}.zip
         ''
       ) dependencyList);
   };

--- a/lib/moonPlatform/buildMoonPackage.nix
+++ b/lib/moonPlatform/buildMoonPackage.nix
@@ -43,13 +43,10 @@ let
     stdenv.mkDerivation (
       args
       // {
-        inherit
-          nativeBuildInputs
-          unpackPhase
-          buildPhase
-          installPhase
-          env
-          ;
+        inherit nativeBuildInputs env;
+        unpackPhase = args.unpackPhase or unpackPhase;
+        buildPhase = args.buildPhase or buildPhase;
+        installPhase = args.installPhase or installPhase;
       }
     );
 in

--- a/lib/moonPlatform/buildMoonPackage.nix
+++ b/lib/moonPlatform/buildMoonPackage.nix
@@ -1,5 +1,14 @@
 # Main builder of moonPlatform.
-# TODO: Build target specific control of $out destination.
+#
+# Reads moon.mod.json to determine version, source directory, and preferred
+# build target so callers need minimal configuration:
+#
+#   pkgs.moonPlatform.buildMoonPackage {
+#     name = "my-app";
+#     src = ./.;
+#     moonModJson = ./moon.mod.json;
+#     moonRegistryIndex = inputs.moon-registry;
+#   }
 {
   lib,
   stdenv,
@@ -13,9 +22,20 @@ let
       moonModJson,
       moonRegistryIndex,
       moonFlags ? [ ],
+      moonMainPkg ? null,
+      moonTarget ? null,
       ...
     }@args:
     let
+      moonMod = builtins.fromJSON (builtins.readFile moonModJson);
+
+      # Auto-detect from moon.mod.json
+      derivedVersion = moonMod.version or "0.0.0";
+      sourceDir = moonMod.source or "src";
+      preferredTarget = moonMod.preferred-target or "native";
+
+      effectiveTarget = if moonTarget != null then moonTarget else preferredTarget;
+
       cachedRegistry = buildCachedRegistry {
         inherit moonModJson;
         registryIndexSrc = moonRegistryIndex;
@@ -24,10 +44,12 @@ let
         inherit cachedRegistry;
       };
       nativeBuildInputs = lib.lists.unique ((args.nativeBuildInputs or [ ]) ++ [ moonHome ]);
+
       unpackPhase = ''
         mkdir -p $TMP
         cp -r $src/* $TMP
       '';
+
       buildPhase = ''
         cd $TMP
 
@@ -39,19 +61,39 @@ let
         export MOON_HOME=$writable_home
         export HOME=$TMPDIR
 
-        moon build ${lib.concatStringsSep " " moonFlags}
+        moon build \
+          --target ${effectiveTarget} \
+          --release \
+          ${lib.concatStringsSep " " moonFlags}
       '';
+
+      # Find and install all executable binaries produced by the build.
       installPhase = ''
-        mkdir -p $out
-        cp -r $TMP/_build/ $out/
+        mkdir -p $out/bin
+        find $TMP/_build/${effectiveTarget}/release/build/ \
+          -name '*.exe' -type f -perm -0111 \
+          -exec sh -c '
+            for f; do
+              base="$(basename "$f" .exe)"
+              install -Dm755 "$f" "$out/bin/$base"
+            done
+          ' _ {} +
       '';
+
       env = (args.env or { }) // {
         MOON_HOME = "${moonHome}";
       };
     in
     stdenv.mkDerivation (
-      args
+      (builtins.removeAttrs args [
+        "moonModJson"
+        "moonRegistryIndex"
+        "moonFlags"
+        "moonMainPkg"
+        "moonTarget"
+      ])
       // {
+        version = args.version or derivedVersion;
         inherit nativeBuildInputs env;
         unpackPhase = args.unpackPhase or unpackPhase;
         buildPhase = args.buildPhase or buildPhase;

--- a/lib/moonPlatform/buildMoonPackage.nix
+++ b/lib/moonPlatform/buildMoonPackage.nix
@@ -96,6 +96,11 @@ let
           ' _ {} +
       '';
 
+      checkPhase = ''
+        cd $TMP
+        moon test --target ${effectiveTarget}
+      '';
+
       env = (args.env or { }) // {
         MOON_HOME = "${moonHome}";
       };
@@ -111,10 +116,12 @@ let
       // {
         name = args.name or derivedName;
         version = args.version or derivedVersion;
+        doCheck = args.doCheck or true;
         inherit nativeBuildInputs env;
         meta = derivedMeta // (args.meta or { });
         unpackPhase = args.unpackPhase or unpackPhase;
         buildPhase = args.buildPhase or buildPhase;
+        checkPhase = args.checkPhase or checkPhase;
         installPhase = args.installPhase or installPhase;
       }
     );

--- a/lib/moonPlatform/buildMoonPackage.nix
+++ b/lib/moonPlatform/buildMoonPackage.nix
@@ -30,11 +30,20 @@ let
       '';
       buildPhase = ''
         cd $TMP
+
+        # MOON_HOME from the nix store is read-only; moon needs to write
+        # build caches and package metadata there, so create a writable copy.
+        writable_home=$TMPDIR/moon_home
+        cp -rL $MOON_HOME $writable_home
+        chmod -R u+w $writable_home
+        export MOON_HOME=$writable_home
+        export HOME=$TMPDIR
+
         moon build ${lib.concatStringsSep " " moonFlags}
       '';
       installPhase = ''
         mkdir -p $out
-        cp -r $TMP/target/ $out/
+        cp -r $TMP/_build/ $out/
       '';
       env = (args.env or { }) // {
         MOON_HOME = "${moonHome}";

--- a/lib/moonPlatform/buildMoonPackage.nix
+++ b/lib/moonPlatform/buildMoonPackage.nix
@@ -4,7 +4,6 @@
 # build target so callers need minimal configuration:
 #
 #   pkgs.moonPlatform.buildMoonPackage {
-#     name = "my-app";
 #     src = ./.;
 #     moonModJson = ./moon.mod.json;
 #     moonRegistryIndex = inputs.moon-registry;
@@ -30,6 +29,8 @@ let
       moonMod = builtins.fromJSON (builtins.readFile moonModJson);
 
       # Auto-detect from moon.mod.json
+      # name is "owner/repo" in moon.mod.json; use the last component
+      derivedName = lib.last (lib.splitString "/" (moonMod.name or "moon-package"));
       derivedVersion = moonMod.version or "0.0.0";
       sourceDir = moonMod.source or "src";
       preferredTarget = moonMod.preferred-target or "native";
@@ -93,6 +94,7 @@ let
         "moonTarget"
       ])
       // {
+        name = args.name or derivedName;
         version = args.version or derivedVersion;
         inherit nativeBuildInputs env;
         unpackPhase = args.unpackPhase or unpackPhase;

--- a/lib/moonPlatform/buildMoonPackage.nix
+++ b/lib/moonPlatform/buildMoonPackage.nix
@@ -37,6 +37,21 @@ let
 
       effectiveTarget = if moonTarget != null then moonTarget else preferredTarget;
 
+      # Reverse-lookup: find a nixpkgs license by its SPDX identifier
+      findLicenseBySpdxId =
+        spdxId:
+        let
+          all = builtins.attrValues lib.licenses;
+          matches = builtins.filter (l: (l.spdxId or "") == spdxId) all;
+        in
+        if matches != [ ] then builtins.head matches else null;
+
+      derivedLicense = if moonMod ? license then findLicenseBySpdxId moonMod.license else null;
+      derivedMeta =
+        lib.optionalAttrs (moonMod ? description) { description = moonMod.description; }
+        // lib.optionalAttrs (moonMod ? repository) { homepage = moonMod.repository; }
+        // lib.optionalAttrs (derivedLicense != null) { license = derivedLicense; };
+
       cachedRegistry = buildCachedRegistry {
         inherit moonModJson;
         registryIndexSrc = moonRegistryIndex;
@@ -97,6 +112,7 @@ let
         name = args.name or derivedName;
         version = args.version or derivedVersion;
         inherit nativeBuildInputs env;
+        meta = derivedMeta // (args.meta or { });
         unpackPhase = args.unpackPhase or unpackPhase;
         buildPhase = args.buildPhase or buildPhase;
         installPhase = args.installPhase or installPhase;

--- a/lib/moonPlatform/bundleWithRegistry.nix
+++ b/lib/moonPlatform/bundleWithRegistry.nix
@@ -24,7 +24,9 @@ symlinkJoin {
   postBuild = ''
     export MOON_HOME=$out
 
-    PATH=$out/bin $out/bin/${toolchains.meta.mainProgram} bundle --all --source-dir $out/lib/core
+    pushd $out/lib/core
+    PATH=$out/bin $out/bin/${toolchains.meta.mainProgram} bundle --all
+    popd
 
     wrapProgram $out/bin/${toolchains.meta.mainProgram} \
       --set MOON_HOME $out

--- a/lib/moonPlatform/default.nix
+++ b/lib/moonPlatform/default.nix
@@ -83,6 +83,7 @@ in
 {
   inherit
     buildCachedRegistry
+    bundleWithRegistry
     buildMoonPackage
     ;
 }

--- a/lib/moonPlatform/listAllDependencies.nix
+++ b/lib/moonPlatform/listAllDependencies.nix
@@ -18,8 +18,9 @@ let
         headIndexRecords = builtins.readFile "${registryIndexSrc}/user/${head.name}.index";
         headIndex = parseMoonIndex headIndexRecords;
         headDependency = headIndex.${head.version};
+        depKey = "${head.name}@${head.version}";
         resolvedDependencies' = resolvedDependencies // {
-          head.name = head.version;
+          "${depKey}" = true;
         };
         unresolvedDependencies' =
           tail
@@ -30,6 +31,6 @@ let
           resolvedDependencies = resolvedDependencies';
         };
       in
-      if builtins.hasAttr head.name resolvedDependencies then next else next ++ [ headDependency ];
+      if builtins.hasAttr depKey resolvedDependencies then next else next ++ [ headDependency ];
 in
 listAllDependencies


### PR DESCRIPTION
## Summary

Several bugs and improvements in `moonPlatform` that make `buildMoonPackage` work with recent moon versions (tested with v0.8.3) and provide a much simpler user experience.

### Before (broken)

```nix
pkgs.moonPlatform.buildMoonPackage {
  name = "my-app";
  src = ./.;
  version = "0.1.0";
  moonModJson = ./moon.mod.json;
  moonRegistryIndex = inputs.moon-registry;
  moonFlags = [ "--release" ];
  meta = { ... };
}
# ❌ Permission denied in buildCachedRegistry
# ❌ moon bundle --source-dir removed
# ❌ MOON_HOME is read-only
# ❌ installPhase references wrong output dir
# ❌ User cannot override phases
# ❌ name, version, meta must be specified manually
# ❌ No tests run during build
```

### After

```nix
pkgs.moonPlatform.buildMoonPackage {
  src = ./.;
  moonModJson = ./moon.mod.json;
  moonRegistryIndex = inputs.moon-registry;
}
# ✅ name, version, target, description, homepage, license
#    all auto-detected from moon.mod.json
# ✅ All binaries installed to $out/bin/ automatically
# ✅ moon test runs by default (doCheck = true)
```

---

### Dependency resolution & caching

- **`listAllDependencies.nix`**: The dedup key used the literal string `"head.name"` (a static attribute name in Nix) instead of the dynamic value `"${head.name}"`. This caused all packages to be added repeatedly without any deduplication, producing hundreds of duplicate `cp` commands in `buildCachedRegistry`.
  Changed the key to `"${head.name}@${head.version}"` so each (name, version) pair is processed exactly once — this also correctly allows multiple versions of the same package to coexist in the cache.

- **`buildCachedRegistry.nix`**: `cp` from a Nix store path preserves the source's read-only permissions on the destination file. Attempting to copy the same file a second time (or any overwrite) would fail with `Permission Denied`. Replaced with `install -Dm644` which sets writable permissions and creates parent directories automatically.

### Core library bundling

- **`bundleWithRegistry.nix`**: `moon bundle --source-dir` was removed in a recent moon release (it now says "unexpected argument, did you mean --target-dir?"). Fixed by `pushd`-ing into the core directory and running `moon bundle --all` without `--target-dir`, so output lands in the default `_build/` location that `moonc` expects at runtime.

### buildMoonPackage

- **Auto-detection from moon.mod.json**:
  - `name` — last component of the module name (e.g. `"mizchi/actrun"` → `"actrun"`)
  - `version` — from `mod.version`
  - `preferred-target` — build target (`native`, `js`, etc.)
  - `source` — source directory
  - `meta.description` — from `mod.description`
  - `meta.homepage` — from `mod.repository`
  - `meta.license` — reverse-lookup of SPDX identifier against `lib.licenses` (no hardcoded mapping)

  All auto-derived values can be overridden by the caller.

- **Testing**: Default `checkPhase` runs `moon test --target <target>`. Enabled by default (`doCheck = true`). Disable with `doCheck = false` for projects whose tests require external processes or network access.

- **User phase overrides**: The computed `unpackPhase`, `buildPhase`, `checkPhase`, and `installPhase` were placed on the right side of the `//` merge, unconditionally overriding any phases the caller passed in args. Now uses `args.phase or defaultPhase` so caller-provided phases take precedence.

- **Writable MOON_HOME**: `MOON_HOME` pointed to a read-only nix store path (`symlinkJoin` output). `moon` needs to write build caches and package metadata into `MOON_HOME` during compilation. The default `buildPhase` now creates a writable copy of `MOON_HOME` in `$TMPDIR`.

- **Correct output path**: The default `installPhase` referenced `$TMP/target/` but moon writes build output to `_build/`. Updated accordingly. Now automatically finds all `*.exe` binaries and installs them to `$out/bin/` (stripping the `.exe` extension).

- **Clean args passthrough**: `moonModJson`, `moonRegistryIndex`, `moonFlags`, `moonTarget`, and `moonMainPkg` are stripped from args before passing to `mkDerivation`, preventing unknown-attribute errors.

### Public API

- **`bundleWithRegistry` exported**: Was not accessible from the public API, making it impossible for users to construct a custom `MOON_HOME` without going through `buildMoonPackage`. Now exposed in `default.nix` alongside `buildCachedRegistry` and `buildMoonPackage`.

### Documentation

- Updated README with minimal `buildMoonPackage` example
- Added optional parameters table
- Documented the three public API functions

## Test plan

- [x] `buildCachedRegistry` completes without permission errors
- [x] All transitive dependency versions are fetched into the registry cache
- [x] `moon bundle` produces `.mi` files at the path `moonc` expects
- [x] `buildMoonPackage` with custom `installPhase` works (user override respected)
- [x] `buildMoonPackage` with minimal config (no name/version/target/meta/installPhase) works
- [x] name, version, description, homepage, license auto-detected from moon.mod.json
- [x] `moon test` runs during `checkPhase` by default
- [x] `doCheck = false` disables test execution
- [x] Native binary is produced and executable
- [x] `nix build` and `nix run` both work