### PR TITLE
ci: weekly update-flake-lock workflow

### DIFF
--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -1,0 +1,36 @@
+# Weekly `nix flake update` → opens a PR. The companion `sync.yaml` only bumps the
+# MoonBit version table (versions/), never the flake INPUTS (nixpkgs, treefmt-nix),
+# so without this the lock drifts (it had fallen ~2 months behind, pinning an old
+# zig). PR-based (not a direct push) so input bumps get reviewed before merge.
+name: Update flake.lock
+
+on:
+  schedule:
+    - cron: '0 3 * * 1' # Mondays 03:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  lockfile:
+    name: Update flake.lock
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v30
+
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@main
+        with:
+          pr-title: 'flake.lock: weekly update'
+          pr-labels: |
+            dependencies
+            automated
+          # NB: the PR is opened with the default GITHUB_TOKEN, so `check.yaml`
+          # (pull_request-triggered) will NOT auto-run on it. Re-push or close/reopen
+          # the PR to trigger the flake check, or wire a PAT here if that matters.

--- a/lib/moonPlatform/buildCachedRegistry.nix
+++ b/lib/moonPlatform/buildCachedRegistry.nix
@@ -23,24 +23,23 @@ let
     name = "cached-moon-registry";
     src = registryIndexSrc;
     phases = [ "installPhase" ];
-    installPhase =
+    installPhase = ''
+      mkdir -p $out/registry/index
+      cp -r $src/* $out/registry/index/
+    ''
+    + (lib.strings.concatMapStringsSep "\n" (
+      dep:
+      let
+        cache = fetchMoonPackage {
+          name = dep.name;
+          version = dep.version;
+          sha256 = dep.checksum;
+        };
+      in
       ''
-        mkdir -p $out/registry/index
-        cp -r $src/* $out/registry/index/
+        install -Dm644 ${cache} $out/registry/cache/${dep.name}/${dep.version}.zip
       ''
-      + (lib.strings.concatMapStringsSep "\n" (
-        dep:
-        let
-          cache = fetchMoonPackage {
-            name = dep.name;
-            version = dep.version;
-            sha256 = dep.checksum;
-          };
-        in
-        ''
-          install -Dm644 ${cache} $out/registry/cache/${dep.name}/${dep.version}.zip
-        ''
-      ) dependencyList);
+    ) dependencyList);
   };
 in
 buildCachedRegistry


### PR DESCRIPTION
## What

Adds `.github/workflows/update-flake-lock.yaml` — a weekly (Mon 03:00 UTC) job that runs `nix flake update` and opens a PR via [`DeterminateSystems/update-flake-lock`](https://github.com/DeterminateSystems/update-flake-lock).

## Why

`sync.yaml`'s daily job only refreshes the **MoonBit version table** (`versions/`), it never touches the **flake inputs** (`nixpkgs`, `treefmt-nix`). As a result `flake.lock` had drifted ~2 months behind and pinned an old `zig` (0.15.2 vs nixpkgs-current 0.16). This closes that gap, the idiomatic Nix way: pinned lock + scheduled, **PR-based** refresh so input bumps get reviewed before merge.

## Note

The PR is opened with the default `GITHUB_TOKEN`, so the `pull_request`-triggered `check.yaml` won't auto-run on the bot PR (a known Actions limitation). Re-push or close/reopen to trigger the flake check, or wire a PAT if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)