### PR TITLE
fix(toolchains): align TinyCC runtime helpers on Linux

### DIFF
--- a/lib/toolchains.nix
+++ b/lib/toolchains.nix
@@ -42,13 +42,19 @@ stdenv.mkDerivation {
 
   ''
   # On Linux the bundled `internal/tcc` is an autopatched ELF that does not
-  # work standalone, so we swap in nixpkgs `tinycc`. On Darwin the bundled
-  # Mach-O `tcc` is what upstream ships and uses, and nixpkgs `tinycc` is
-  # currently marked broken on aarch64-darwin (see issue #40), so keep the
-  # bundled one there. The boundary is the platform, not the version.
+  # work standalone, so we swap in nixpkgs `tinycc` and its matching runtime
+  # helpers. On Darwin the bundled Mach-O `tcc` is what upstream ships and
+  # uses, and nixpkgs `tinycc` is currently marked broken on aarch64-darwin
+  # (see issue #40), so keep the bundled toolchain there. The boundary is the
+  # platform, not the version.
   + lib.optionalString stdenv.hostPlatform.isLinux ''
     rm $out/bin/internal/tcc
     ln -sf ${tinycc.out}/bin/tcc $out/bin/internal/tcc
+
+    for helper in libtcc1.a runmain.o bcheck.o bt-exe.o bt-log.o; do
+      rm -f "$out/lib/$helper"
+      ln -s "${tinycc.lib}/lib/tcc/$helper" "$out/lib/$helper"
+    done
   ''
   + ''
 


### PR DESCRIPTION
## Summary

When replacing the bundled `internal/tcc` with nixpkgs TinyCC on Linux, also replace the corresponding runtime helper files with those from the same nixpkgs package:

- `libtcc1.a`
- `runmain.o`
- `bcheck.o`
- `bt-exe.o`
- `bt-log.o`

## Background

The current Linux packaging replaces only `bin/internal/tcc` while retaining the runtime helpers bundled with MoonBit. This mixes different TinyCC revisions. In this configuration, nixpkgs TinyCC emits a reference to `__mzerodf`, but the newer bundled `libtcc1.a` does not provide that symbol, resulting in:

`tcc: error: undefined symbol '__mzerodf'`

Darwin remains unchanged and continues to use the bundled TCC and its matching runtime helpers.

## Validation

- `nix fmt -- --fail-on-change lib/toolchains.nix`
- `nix eval --raw .#packages.x86_64-linux.toolchains_latest.drvPath`
- Verified on linux/amd64 Docker that the replaced helper files resolve to the nixpkgs TinyCC package and that `internal/tcc -run` successfully executes floating-point negation code.

The full `nix flake check --no-build` is currently blocked by a pre-existing fixed-output hash mismatch for the Moon registry, unrelated to this change.
